### PR TITLE
Updated release notes to mention support of CVO on SELinux (also updated dark site 3.9.48 date)

### DIFF
--- a/_whatsnew/2025-02-18.adoc
+++ b/_whatsnew/2025-02-18.adoc
@@ -1,0 +1,27 @@
+=== Private mode release (3.9.48)
+
+A new private mode release is now available to download from the https://mysupport.netapp.com/site/downloads[NetApp Support Site^] 
+
+The 3.9.48 release includes updates to the following BlueXP components and services.
+
+[cols=3*,options="header,autowidth"]
+|===
+
+| Component or service
+| Version included in this release
+| Changes since the previous private mode release
+
+| Connector | 3.9.48 | Go to the https://docs.netapp.com/us-en/bluexp-setup-admin/whats-new.html#connector-3-9-48[what's new in BlueXP connector page] and refer to the changes included for versions 3.9.48.
+
+| Backup and recovery | 21 February 2025 | Go to the https://docs.netapp.com/us-en/bluexp-backup-recovery/whats-new.html[what's new in BlueXP backup and recovery page^] and refer to the changes included in the February 2025 release.
+
+| Classification | 22 January 2025 (version 1.39) | Go to the https://docs.netapp.com/us-en/bluexp-classification/whats-new.html[what's new in BlueXP classification page^] and refer to the changes included in the 1.39 release.
+
+
+|===
+
+
+
+
+
+

--- a/_whatsnew/2025-03-10.adoc
+++ b/_whatsnew/2025-03-10.adoc
@@ -5,6 +5,12 @@
 
 This release of the BlueXP Connector includes minor security improvements and bug fixes.
 
+* Management of Cloud Volumes ONTAP systems is now supported by Connectors that have SELinux enabled on the operating system.
+
++
+
+https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/8/html/using_selinux/getting-started-with-selinux_using-selinux[Learn more about SELinux^]
+
 At this time, the 3.9.50 release is available for standard mode and restricted mode.
 
 === NetApp Keystone beta available in BlueXP

--- a/whats-new.adoc
+++ b/whats-new.adoc
@@ -36,6 +36,10 @@ include::_whatsnew/2025-03-10.adoc[]
 
 include::_whatsnew/2025-03-06.adoc[]
 
+== 18 February 2025
+
+include::_whatsnew/2025-02-18.adoc[]
+
 == 10 February 2025
 
 include::_whatsnew/2025-02-10.adoc[]


### PR DESCRIPTION
This pull request updates documentation for BlueXP releases, including details about new features, improvements, and integration with SELinux. The most important changes are divided into two themes: new release announcements and SELinux support.

### New release announcements:

* [`_whatsnew/2025-02-18.adoc`](diffhunk://#diff-cca036d86d4cd465b983ca54385a814b5ea91168e97d380fa85092361efc04c8R1-R27): Added details about the 3.9.48 private mode release, including updates to the BlueXP Connector, Backup and Recovery, and Classification components. Links to the respective "What's New" pages for detailed changes are included.
* [`whats-new.adoc`](diffhunk://#diff-48c20d0c197b67df2ca82e007a452fe1a1322654b4be4306665dba10419a2242R39-R42): Included the `_whatsnew/2025-02-18.adoc` file under the "18 February 2025" section to ensure the new release is documented in the main changelog.

### SELinux support:

* [`_whatsnew/2025-03-10.adoc`](diffhunk://#diff-49ed897a76dff908502cb8a141f443f26db78fcd61c9e68fbf199070d75cc36eR8-R13): Documented that the management of Cloud Volumes ONTAP systems is now supported by BlueXP Connectors running on operating systems with SELinux enabled. A link to SELinux documentation is provided for additional context.