### PR TITLE
Fix storage roles table

### DIFF
--- a/reference-iam-predefined-roles.adoc
+++ b/reference-iam-predefined-roles.adoc
@@ -56,15 +56,6 @@ NOTE: Accessing Keystone through BlueXP is currently in beta. If you would like 
 | link:reference-iam-keystone-roles.html[Keystone admin] | Users with the Keystone admin role can create service requests. Allows users to monitor and view consumption, assets, and administrative information within the Keystone tenant they are accessing.
 
 | link:reference-iam-keystone-roles.html[Keystone viewer] | Users with the Keystone viewer role CANNOT make service requests. Allows users to monitor and view consumption, assets, and administrative information within the Keystone tenant they are accessing.
-
-////
-| link:reference-iam-storage-roles.html[Storage admin] | Administer storage health and governance functions, discover storage resources, as well as modify and delete existing working environments.
-| link:reference-iam-storage-roles.html[Storage viewer] | View storage health and governance functions, as well as view previously discovered storage resources. Cannot discover, modify, or delete existing storage working environments.
-| link:reference-iam-storage-roles.html[System health specialist] | Administer storage and health and governance functions, all permissions of the Storage admin except cannot modify or delete existing working environments.
-
-// hiding storage roles
-////
-
 |===
 
 

--- a/reference-iam-predefined-roles.adoc
+++ b/reference-iam-predefined-roles.adoc
@@ -53,9 +53,9 @@ NOTE: Accessing Keystone through BlueXP is currently in beta. If you would like 
 |===
 | Application role | Responsibilities
 
-| link:reference-iam-keystone-roles.html[Keystone admin] | Users with the Keystone admin role can create service requests. Allows users to monitor and view consumption, assets, and administrative information within the Keystone tenant they are accessing.
+| link:reference-iam-keystone-roles.html[Keystone admin^] | Users with the Keystone admin role can create service requests. Allows users to monitor and view consumption, assets, and administrative information within the Keystone tenant they are accessing.
 
-| link:reference-iam-keystone-roles.html[Keystone viewer] | Users with the Keystone viewer role CANNOT create service requests. Allows users to monitor and view consumption, assets, and administrative information within the Keystone tenant they are accessing.
+| link:reference-iam-keystone-roles.html[Keystone viewer^] | Users with the Keystone viewer role CANNOT create service requests. Allows users to monitor and view consumption, assets, and administrative information within the Keystone tenant they are accessing.
 |===
 
 

--- a/reference-iam-predefined-roles.adoc
+++ b/reference-iam-predefined-roles.adoc
@@ -55,7 +55,7 @@ NOTE: Accessing Keystone through BlueXP is currently in beta. If you would like 
 
 | link:reference-iam-keystone-roles.html[Keystone admin] | Users with the Keystone admin role can create service requests. Allows users to monitor and view consumption, assets, and administrative information within the Keystone tenant they are accessing.
 
-| link:reference-iam-keystone-roles.html[Keystone viewer] | Users with the Keystone viewer role CANNOT make service requests. Allows users to monitor and view consumption, assets, and administrative information within the Keystone tenant they are accessing.
+| link:reference-iam-keystone-roles.html[Keystone viewer] | Users with the Keystone viewer role CANNOT create service requests. Allows users to monitor and view consumption, assets, and administrative information within the Keystone tenant they are accessing.
 |===
 
 


### PR DESCRIPTION
This pull request simplifies the documentation by removing references to storage roles and updating the descriptions of Keystone roles. The most significant changes are outlined below:

### Documentation Updates:

* Removed all references to storage roles (`Storage admin`, `Storage viewer`, and `System health specialist`) from the predefined roles documentation. These roles were previously hidden and are no longer included in the table.
* Updated the descriptions of `Keystone admin` and `Keystone viewer` roles to include a caret symbol (`^`) in their links and clarified that the `Keystone viewer` role cannot create service requests.