### PR TITLE
Bluexpdoc 483 connector updates

### DIFF
--- a/_whatsnew/2025-05-12.adoc
+++ b/_whatsnew/2025-05-12.adoc
@@ -10,7 +10,7 @@ Docker 27 and Docker 28 are now supported with the Connector.
 
 
 ==== Cloud Volumes ONTAP 
-Cloud Volumes ONTAP PAYGO licenses and capacity-based licenses now keep running if the Connector is shutdown for more than 14 days. This removes a previous limitation that required the Connector to be running for the license to remain valid.
+Cloud Volumes ONTAP PAYGO licenses and capacity-based licenses no longer shutdown when the Connector is out of compliance or down for more than 14 days. Cloud Volumes ONTAP still sends Event Management messages when it loses access to the Connector. This change is to ensure that Cloud Volumes ONTAP can continue to operate even if the Connector is down for an extended period of time. It does not change compliance requirements for the Connector.
 
 
 

--- a/_whatsnew/2025-05-12.adoc
+++ b/_whatsnew/2025-05-12.adoc
@@ -10,7 +10,7 @@ Docker 27 and Docker 28 are now supported with the Connector.
 
 
 ==== Cloud Volumes ONTAP 
-Cloud Volumes ONTAP PAYGO licenses and capacity-based licenses no longer shutdown when the Connector is out of compliance or down for more than 14 days. Cloud Volumes ONTAP still sends Event Management messages when it loses access to the Connector. This change is to ensure that Cloud Volumes ONTAP can continue to operate even if the Connector is down for an extended period of time. It does not change compliance requirements for the Connector.
+Cloud Volumes ONTAP capacity-based nodes no longer shutdown when the Connector is out of compliance or down for more than 14 days. Cloud Volumes ONTAP still sends Event Management messages when it loses access to the Connector. This change is to ensure that Cloud Volumes ONTAP can continue to operate even if the Connector is down for an extended period of time. It does not change compliance requirements for the Connector.
 
 
 


### PR DESCRIPTION
This pull request updates the documentation to clarify the behavior of Cloud Volumes ONTAP capacity-based nodes when the Connector is down for an extended period.

Documentation update:

* [`_whatsnew/2025-05-12.adoc`](diffhunk://#diff-da4139c85169a83107a086d613d28a527519fc218e4528d40fcbb1beb09ca330L13-R13): Revised the description to specify that Cloud Volumes ONTAP capacity-based nodes no longer shut down when the Connector is out of compliance or down for more than 14 days. Instead, Event Management messages are sent, ensuring continued operation while maintaining compliance requirements.