### PR TITLE
Bluexpdoc 222 storage roles

### DIFF
--- a/_whatsnew/2025-05-12.adoc
+++ b/_whatsnew/2025-05-12.adoc
@@ -18,7 +18,7 @@ Cloud Volumes ONTAP capacity-based nodes no longer shutdown when the Connector i
 
 The beta for NetApp Keystone in BlueXP has added access to Keystone administration. You can access the sign-up page for the NetApp Keystone beta from the left navigation bar of BlueXP.
 
-////
+
 === BlueXP Identity and Access Management (IAM)
 
 ==== New storage management roles
@@ -64,9 +64,7 @@ View storage health information and governance data.
 
 link:https://docs.netapp.com/us-en/bluexp-setup-admin/reference-iam-predefined-roles.html[Learn about access roles.^]
 
-// hiding the storage roles
 
-////
 
 
 

--- a/concept-accounts-aws.adoc
+++ b/concept-accounts-aws.adoc
@@ -5,7 +5,7 @@ keywords: cloud provider accounts, aws, aws accounts, keys, multiple accounts, p
 summary: Learn how BlueXP uses AWS credentials to perform actions on your behalf and how those credentials are associated with marketplace subscriptions. Understanding these details can be helpful as you manage the credentials for one or more AWS accounts in BlueXP. For example, you might want to learn about when to add additional AWS credentials to BlueXP.
 ---
 
-= Learn about AWS credentials and permissions
+= Learn about AWS credentials and permissions in BlueXP
 :hardbreaks:
 :nofooter:
 :icons: font

--- a/concept-accounts-azure.adoc
+++ b/concept-accounts-azure.adoc
@@ -5,7 +5,7 @@ keywords: cloud provider accounts, azure, azure accounts, service principal, mul
 summary: Learn how BlueXP uses Azure credentials to perform actions on your behalf and how those credentials are associated with marketplace subscriptions. Understanding these details can be helpful as you manage the credentials for one or more Azure subscriptions. For example, you might want to learn when to add additional Azure credentials to BlueXP.
 ---
 
-= Learn about Azure credentials and permissions
+= Learn about Azure credentials and permissions in BlueXP
 :hardbreaks:
 :nofooter:
 :icons: font

--- a/concept-connectors.adoc
+++ b/concept-connectors.adoc
@@ -87,11 +87,6 @@ Connectors are a fundamental part of the BlueXP service architecture. It's your 
 
 This documentation is governed by the EULA. If the product is not operated in accordance with the documentation, the functionality and operation of the product, as well as your rights under the EULA, may be adversely impacted.
 
-=== Impact on Cloud Volumes ONTAP
-
-A Connector is a key component in the health and operation of Cloud Volumes ONTAP. If a Connector is powered down, Cloud Volumes ONTAP PAYGO systems and capacity-based BYOL systems shut down after losing communication with a Connector for longer than 14 days. This happens because the Connector refreshes licensing on the system each day.
-
-If your Cloud Volumes ONTAP system has a node-based BYOL license, the system remains running after 14 days because the license is installed on the Cloud Volumes ONTAP system.
 
 == Supported locations
 

--- a/project.yml
+++ b/project.yml
@@ -138,6 +138,8 @@ sidebar:
                   entries:
                    - title: Keystone roles 
                      url: /reference-iam-keystone-roles.html
+                   - title: Storage 
+                     url: /reference-iam-storage.roles.html
                 - title: Data services roles
                   entries:
                     - title: Ransomware protection roles

--- a/project.yml
+++ b/project.yml
@@ -138,7 +138,7 @@ sidebar:
                   entries:
                    - title: Keystone roles 
                      url: /reference-iam-keystone-roles.html
-                   - title: Storage 
+                   - title: Storage roles
                      url: /reference-iam-storage.roles.html
                 - title: Data services roles
                   entries:

--- a/reference-iam-predefined-roles.adoc
+++ b/reference-iam-predefined-roles.adoc
@@ -56,6 +56,9 @@ NOTE: Accessing Keystone through BlueXP is currently in beta. If you would like 
 | link:reference-iam-keystone-roles.html[Keystone admin] | Users with the Keystone admin role can create service requests. Allows users to monitor and view consumption, assets, and administrative information within the Keystone tenant they are accessing.
 
 | link:reference-iam-keystone-roles.html[Keystone viewer] | Users with the Keystone viewer role CANNOT create service requests. Allows users to monitor and view consumption, assets, and administrative information within the Keystone tenant they are accessing.
+| link:reference-iam-storage-roles.html[Storage admin] | Administer storage health and governance functions, discover storage resources, as well as modify and delete existing working environments.
+| link:reference-iam-storage-roles.html[Storage viewer] | View storage health and governance functions, as well as view previously discovered storage resources. Cannot discover, modify, or delete existing storage working environments.
+| link:reference-iam-storage-roles.html[System health specialist] | Administer storage and health and governance functions, all permissions of the Storage admin except cannot modify or delete existing working environments.
 |===
 
 

--- a/reference-iam-storage-roles.adoc
+++ b/reference-iam-storage-roles.adoc
@@ -16,6 +16,10 @@ summary: BlueXP identity and access management provides two administrative roles
 
 You can assign the following roles to users to provide them access to the storage management features in BlueXP that are associated with supported storage resources. Users can be assigned either an administrative role which allows them to take action in storage management or a viewer role if they just have monitoring responsibilities.
 
+Users must have associated their BlueXP account with their NetApp Support Site (NSS) account in order to manage the supported storage resources. They must also have network access to the resources they want to manage. For example, if a user wants to manage an ONTAP cluster, they must have network access to the cluster management LIFs (logical interfaces) for the cluster.
+
+NOTE: These roles are not available from the BlueXP partnership API.
+
 Storage roles can be assigned to users for the following storage resources and features:
 
 Storage resources: 

--- a/reference-iam-storage-roles.adoc
+++ b/reference-iam-storage-roles.adoc
@@ -16,8 +16,6 @@ summary: BlueXP identity and access management provides two administrative roles
 
 You can assign the following roles to users to provide them access to the storage management features in BlueXP that are associated with supported storage resources. Users can be assigned either an administrative role which allows them to take action in storage management or a viewer role if they just have monitoring responsibilities.
 
-Users must have associated their BlueXP account with their NetApp Support Site (NSS) account in order to manage the supported storage resources. They must also have network access to the resources they want to manage. For example, if a user wants to manage an ONTAP cluster, they must have network access to the cluster management LIFs (logical interfaces) for the cluster.
-
 NOTE: These roles are not available from the BlueXP partnership API.
 
 Storage roles can be assigned to users for the following storage resources and features:


### PR DESCRIPTION
This pull request includes updates to documentation across multiple files to improve clarity, add new roles, and remove outdated information. The most notable changes include refining role descriptions, introducing new storage roles, and removing obsolete details about Cloud Volumes ONTAP licensing behavior.

### Updates to roles and permissions documentation:
* [`reference-iam-predefined-roles.adoc`](diffhunk://#diff-0bdacb7ad2508aa303197b94b51d24a84f7b36c5387f667881d00926f3f87123R59-R61): Added descriptions for new storage roles, including `Storage admin`, `Storage viewer`, and `System health specialist`. These roles define permissions for managing storage health, governance, and working environments.
* [`reference-iam-storage-roles.adoc`](diffhunk://#diff-b552852aee227396762c71d0a03d279b0a06dddc9a555c9df934fc6d5dd2aafeR19-R20): Clarified that storage roles are not available via the BlueXP partnership API and provided details about the scope of these roles.

### Removal of outdated information:
* [`concept-connectors.adoc`](diffhunk://#diff-213d041e3ac2aeb12dd2211bea12813eec68f9b73cf2973cc920afd859e3ab78L90-L94): Removed details about Cloud Volumes ONTAP systems shutting down after losing communication with a Connector for 14 days, as this behavior is no longer applicable.

### Refinements to titles and navigation:
* `concept-accounts-aws.adoc` and `concept-accounts-azure.adoc`: Updated titles to specify the context of credentials and permissions within BlueXP for better clarity. [[1]](diffhunk://#diff-7ac632eca3fcf990b4c25549f68f19bf0443ca0facd2d2fee110d5ae12d05f2fL8-R8) [[2]](diffhunk://#diff-68d30ab055376b0ec7e8170213aa09c312f357c73646a088b069e9c63f5e1d64L8-R8)
* [`project.yml`](diffhunk://#diff-4f3430205157bae48d1786fcd16dbaaa50f9a1dc46b93ff9ccd26487c269b317R141-R142): Added a new sidebar entry for "Storage roles" to improve navigation for IAM-related documentation.