### PR TITLE
fixed broken link

### DIFF
--- a/_whatsnew/2025-06-09.adoc
+++ b/_whatsnew/2025-06-09.adoc
@@ -5,7 +5,7 @@ This release of the BlueXP Connector includes security improvements and bug fixe
 The 3.9.53 release is available for standard mode and restricted mode.
 
 === Disk space usage alerts
-The Notifications Center now includes alerts for disk space usage on the Connector. link:task-maintain-connectors.html#monitor-disk-space[Learn more.^]
+The Notifications Center now includes alerts for disk space usage on the Connector. link:https://docs.netapp.com/us-en/bluexp-setup-admin/task-maintain-connectors.html#monitor-disk-space[Learn more.^]
 
 === Audit improvements
 The Timeline now includes login and logout events for users. You can see when login activity, which can help with auditing and security monitoring. API users who have the Organization administrator role can view the email address of the user who logged in by including the `includeUserData=true`` parameter as in the following: `/audit/<account_id>?includeUserData=true`.


### PR DESCRIPTION
This pull request includes a single change to the `_whatsnew/2025-06-09.adoc` file. The change updates a documentation link in the "Disk space usage alerts" section to point to a more specific and accurate URL.