### PR TITLE
Updated link

### DIFF
--- a/_whatsnew/2025-06-09.adoc
+++ b/_whatsnew/2025-06-09.adoc
@@ -5,7 +5,7 @@ This release of the BlueXP Connector includes security improvements and bug fixe
 The 3.9.53 release is available for standard mode and restricted mode.
 
 === Disk space usage alerts
-The Notifications Center now includes alerts for disk space usage on the Connector. link:task-maintain-connectors.html#monitor-disk-space[Learn more.^]
+The Notifications Center now includes alerts for disk space usage on the Connector. link:https://docs.netapp.com/us-en/bluexp-setup-admin/task-maintain-connectors.html#monitor-disk-space[Learn more.^]
 
 === Audit improvements
 The Timeline now includes login and logout events for users. You can see when login activity, which can help with auditing and security monitoring. API users who have the Organization administrator role can view the email address of the user who logged in by including the `includeUserData=true`` parameter as in the following: `/audit/<account_id>?includeUserData=true`.

--- a/_whatsnew/2025-06-09.adoc
+++ b/_whatsnew/2025-06-09.adoc
@@ -8,7 +8,7 @@ The 3.9.53 release is available for standard mode and restricted mode.
 The Notifications Center now includes alerts for disk space usage on the Connector. link:task-maintain-connectors.html#monitor-disk-space[Learn more.^]
 
 === Audit improvements
-The Timeline now includes login events for users. This enables you to see when users logged in to BlueXP, which can help with auditing and security monitoring. API users who have the Organization administrator role can view the email address of the user who logged in by including the `includeUserData=true`` parameter as in the following: `/audit/<account_id>?includeUserData=true`.
+The Timeline now includes login and logout events for users. You can see when login activity, which can help with auditing and security monitoring. API users who have the Organization administrator role can view the email address of the user who logged in by including the `includeUserData=true`` parameter as in the following: `/audit/<account_id>?includeUserData=true`.
 
 
 

--- a/concept-accounts-aws.adoc
+++ b/concept-accounts-aws.adoc
@@ -1,7 +1,7 @@
 ---
 sidebar: sidebar
 permalink: concept-accounts-aws.html
-keywords: cloud provider accounts, aws, aws accounts, keys, multiple accounts, permission, aws permissions, policy, policies, credentials, marketplace subscription, replace subscription, subscription, amazon
+keywords: cloud provider accounts, aws, aws accounts, keys, multiple accounts, permission, aws permissions, policy, policies, credentials, marketplace, subscription, replace subscription, subscription, amazon
 summary: Learn how BlueXP uses AWS credentials to perform actions on your behalf and how those credentials are associated with marketplace subscriptions. Understanding these details can be helpful as you manage the credentials for one or more AWS accounts in BlueXP. For example, you might want to learn about when to add additional AWS credentials to BlueXP.
 ---
 


### PR DESCRIPTION
This pull request includes a minor update to the `concept-accounts-aws.adoc` file. The change modifies the `keywords` metadata by splitting "marketplace subscription" into two separate keywords: "marketplace" and "subscription."