### PR TITLE
Cleaned up some typos

### DIFF
--- a/task-configuring-proxy.adoc
+++ b/task-configuring-proxy.adoc
@@ -111,7 +111,7 @@ When you configure a proxy server, the Connector restarts. Verify the Connector 
 
 .Steps
 
-+ Ensure that you have a certificate file in PEM format for the proxy server. If you do not have a certificate, contact your network administrator to obtain one.
+Ensure that you have a certificate file in PEM format for the proxy server. If you do not have a certificate, contact your network administrator to obtain one.
 
 . Open a command-line interface on the Connector host.
 


### PR DESCRIPTION
This pull request includes a minor change to the `task-configuring-proxy.adoc` file. The change removes an unnecessary leading '+' character from a step description in the proxy configuration instructions.