### PR TITLE
Update link in release notes

### DIFF
--- a/_whatsnew/2025-07-21.adoc
+++ b/_whatsnew/2025-07-21.adoc
@@ -1,6 +1,6 @@
 
 === Support for Google Cloud NetApp Volumes
-You can now view Google Cloud NetApp Volumes in BlueXP. link:https://docs.netapp.com/us-en/bluexp-cloud-volumes-service-gcp/index.html[Learn more about Google Cloud NetApp Volumes.]
+You can now view Google Cloud NetApp Volumes in BlueXP. link:https://docs.netapp.com/us-en//bluexp-google-cloud-netapp-volumes/index.html/index.html[Learn more about Google Cloud NetApp Volumes.]
 
 === BlueXP Identity and Access Management (IAM)
 


### PR DESCRIPTION
This pull request includes a small change to the `_whatsnew/2025-07-21.adoc` file. The change updates the documentation link for Google Cloud NetApp Volumes to point to the correct URL.