### PR TITLE
fixed broken link

### DIFF
--- a/_whatsnew/2025-07-21.adoc
+++ b/_whatsnew/2025-07-21.adoc
@@ -12,7 +12,7 @@ BlueXP now supports using an access role for the following storage system:
 * Google Cloud NetApp Volumes 
 
 
-link:https://docs.netapp.com/us-en/bluexp-admin/reference-iam-predefined-roles.html[Learn more about using access roles.]
+link:https://docs.netapp.com/us-en/bluexp-setup-admin/reference-iam-predefined-roles.html[Learn more about using access roles.]
 
 
 


### PR DESCRIPTION
This pull request includes a small update to a documentation file. The change corrects a hyperlink to point to the appropriate page for information about using access roles.

* [`_whatsnew/2025-07-21.adoc`](diffhunk://#diff-1203315369567657625bc899a839f172738344df6bc07a37d658bf8c51ffb12bL15-R15): Updated the link for "Learn more about using access roles" to direct users to the correct URL (`bluexp-setup-admin` instead of `bluexp-admin`).