### PR TITLE
Federation fix

### DIFF
--- a/task-federation-import.adoc
+++ b/task-federation-import.adoc
@@ -22,7 +22,6 @@ NOTE: After you import your existing federation, you can manage the federation f
 .Required role
 Organization admin or Federation admin. link:reference-iam-predefined-roles.html[Learn more about access roles.]
 
-== Import a federation
 
 
 .Steps
@@ -32,82 +31,6 @@ Organization admin or Federation admin. link:reference-iam-predefined-roles.html
 . Select the *Federation* tab.
 
 . Select *Import Federation*.
-
-
-
-
-
-== Add a verified domain to an existing federation
-You can add a verified domain to an existing federation in BlueXP. You can add a verified domain to an existing federation in BlueXP to use multiple domains with the same identity provider (IdP).
-
-You must have already verified the domain in BlueXP before you can add it to a federation. If you haven't verified the domain yet, you can do so by following the steps in the link:task-federation-verify-domain.html[Verify your domain in BlueXP].
-
-<need a use case here of when you would want to do this>--Tonia
-<how long does it take for users of this new domain to be able to log in?--Tonia>
-.Steps
-
-. In the upper right of the BlueXP console, select image:icon-settings-option.png[The settings icon which displays in the top right of the BlueXP web console.] > *Identity & Access Management*.
-
-. Select the *Federation* tab.
-
-. Select the actions menu image:button_3_vert_dots.png[an icon with three vertical dots] next to the federation that you want to add a verified domain to and select *Update domains*. The *Update domains* dialog box lists the domain already associated with this federation.
-
-. Select a verified domain from the list of available domains. 
-
-. Select *Update*.
-
-
-
-== Updating an expiring federated connection
-
-You can update the details of a federated connection in BlueXP. For example, you'll need to update the federation if the credentials such as a certificate or client secret expire. When needed, update the notification date to remind you to update the connection before it expires.
-
-
-IMPORTANT: Update the IdP first before updating the connection in BlueXP to avoid login issues. Stay logged in to BlueXP during the process. --what is the order here?--Tonia
-
-.Steps
-
-. In the upper right of the BlueXP console, select image:icon-settings-option.png[The settings icon which displays in the top right of the BlueXP web console.] > *Identity & Access Management*.
-
-. Select the *Federation* tab.
-
-. Select the actions menu (three vertical dots) next to the federation that you want to add a verified domain to and select *Update federation*. The *Update domains* dialog box lists the domain already associated with this federation.
-
-. Update the details of the federation as needed.
-. Select *Update*.
-
-
-== Test an existing federation
-If you are having trouble with an existing federation, you can test the connection to see if it is working properly. This can help you identify any issues with the federation and troubleshoot them.
-
-.Steps
-
-. In the upper right of the BlueXP console, select image:icon-settings-option.png[The settings icon which displays in the top right of the BlueXP web console.] > *Identity & Access Management*.
-
-. Select the *Federation* tab.
-
-. Select the actions menu image:button_3_vert_dots.png[an icon with three vertical dots] next to the federation that you want to add a verified domain to and select *Test connection*. 
-
-. Select *Test*. You're prompted to log in with your corporate credentials. If the connection is successful, you will be redirected to the BlueXP console. If the connection fails, you will see an error message indicating the issue with the federation.
-
-. Select *Done* to return to the *Federation* tab.
-
-== Disable a federation
-If you no longer need a federation, you can disable it. This prevents users associated with the federation from logging in to BlueXP using their corporate credentials. You can re-enable the federation later if needed.
-
-When should a user disable a federation? For example, if the IdP is being updated or if the federation is no longer needed. --Tonia?
-
-.Steps
-
-. In the upper right of the BlueXP console, select image:icon-settings-option.png[The settings icon which displays in the top right of the BlueXP web console.] > *Identity & Access Management*.
-
-. Select the *Federation* tab.
-
-. Select the actions menu image:button_3_vert_dots.png[an icon with three vertical dots] next to the federation that you want to add a verified domain to and select *Disable*. 
-
-== Delete a federation
-If you no longer need a federation, you can delete it. This removes the federation from BlueXP and prevents any users associated with the federation from logging in to BlueXP using their corporate credentials. For example, if the IdP is being decommissioned or if the federation is no longer needed. After you delete a federation, you cannot recover it. You must create a new federation.
-
 
 
 


### PR DESCRIPTION
This pull request simplifies and streamlines the `task-federation-import.adoc` documentation by removing redundant or outdated sections. The changes focus on improving clarity and reducing unnecessary content.

### Documentation cleanup:

* Removed sections detailing how to add a verified domain, update an expiring federated connection, test an existing federation, disable a federation, and delete a federation. These sections were likely deemed redundant 

### Structural changes:

* Removed the "Import a federation" section heading to consolidate or simplify the structure of the document.