### PR TITLE
fixed google URL

### DIFF
--- a/_whatsnew/2025-07-21.adoc
+++ b/_whatsnew/2025-07-21.adoc
@@ -1,6 +1,6 @@
 
 === Support for Google Cloud NetApp Volumes
-You can now view Google Cloud NetApp Volumes in BlueXP. link:https://docs.netapp.com/us-en//bluexp-google-cloud-netapp-volumes/index.html/index.html[Learn more about Google Cloud NetApp Volumes.]
+You can now view Google Cloud NetApp Volumes in BlueXP. link:https://docs.netapp.com/us-en//bluexp-google-cloud-netapp-volumes/index.html[Learn more about Google Cloud NetApp Volumes.]
 
 === BlueXP Identity and Access Management (IAM)
 


### PR DESCRIPTION
This pull request fixes a broken link in the `_whatsnew/2025-07-21.adoc` file. The updated link now correctly points to the Google Cloud NetApp Volumes documentation.

* [`_whatsnew/2025-07-21.adoc`](diffhunk://#diff-1203315369567657625bc899a839f172738344df6bc07a37d658bf8c51ffb12bL3-R3): Corrected the URL for the "Learn more about Google Cloud NetApp Volumes" link by removing the duplicate `/index.html` at the end.