### PR TITLE
Bluexpdoc 671 darksite

### DIFF
--- a/_whatsnew/2025-07-31.adoc
+++ b/_whatsnew/2025-07-31.adoc
@@ -1,0 +1,31 @@
+=== Private mode release (3.9.52)
+
+A new private mode release is now available to download from the https://mysupport.netapp.com/site/downloads[NetApp Support Site^] 
+
+The 3.9.54 release includes updates to the following BlueXP components and services.
+
+[cols=3*,options="header,autowidth"]
+|===
+
+| Component or service
+| Version included in this release
+| Changes since the previous private mode release
+
+| Connector | 3.9.54, 3.9.53 | Go to the https://docs.netapp.com/us-en/bluexp-setup-admin/whats-new.html#connector-3-9-50[what's new in BlueXP page^] and refer to the changes included for versions 3.9.54 and 3.9.53.
+
+| Backup and recovery | 22 July 2025 | Go to the https://docs.netapp.com/us-en/bluexp-backup-recovery/whats-new.html[what's new in BlueXP backup and recovery page^] and refer to the changes included in the July 2025 release.
+
+| Classification | 14 July 2025 (version 1.45) | Go to the https://docs.netapp.com/us-en/bluexp-classification/whats-new.html[what's new in BlueXP classification page^].
+
+
+|===
+
+
+
+For more details about private mode, including how to upgrade, refer to the following:
+
+* https://docs.netapp.com/us-en/bluexp-setup-admin/concept-modes.html[Learn about private mode]
+
+* https://docs.netapp.com/us-en/bluexp-setup-admin/task-quick-start-private-mode.html[Learn how to get started with BlueXP in private mode]
+
+* https://docs.netapp.com/us-en/bluexp-setup-admin/task-upgrade-connector.html[Learn how to upgrade the Connector when using private mode]

--- a/whats-new.adoc
+++ b/whats-new.adoc
@@ -19,6 +19,9 @@ Learn what's new with BlueXP administration features: identity and access manage
 
 // tag::whats-new[]
 
+== 31 July 2025
+include::_whatsnew/2025-07-31.adoc[]
+
 == 21 July 2025
 include::_whatsnew/2025-07-21.adoc[]
 
@@ -29,11 +32,13 @@ include::_whatsnew/2025-07-14.adoc[]
 
 include::_whatsnew/2025-06-09.adoc[]
 
+// end::whats-new[]
+
 == 29 May 2025
 
 include::_whatsnew/2025-05-29.adoc[]
 
-// end::whats-new[]
+
 
 == 12 May 2025
 


### PR DESCRIPTION
This pull request introduces updates to the documentation for BlueXP, including a new private mode release announcement, removal of outdated federation-related content, and updates to the "What's New" section. The key changes are summarized below:

### New Feature Announcement
* Added details about the 3.9.54 private mode release in `_whatsnew/2025-07-31.adoc`, including updates to various BlueXP components and links to relevant documentation.

### Documentation Cleanup
* Removed outdated federation-related content from `task-federation-import.adoc`, including instructions for adding verified domains, updating federated connections, testing federations, disabling federations, and deleting federations. [[1]](diffhunk://#diff-a05fcb861aad3abdc8fbc8b3d25fd82fefcee3f5a10cfa77fe0182d20ab72e21L25) [[2]](diffhunk://#diff-a05fcb861aad3abdc8fbc8b3d25fd82fefcee3f5a10cfa77fe0182d20ab72e21L40-L115)

### Updates to "What's New" Section
* Included the new `_whatsnew/2025-07-31.adoc` file in the "What's New" section of `whats-new.adoc` for the 31 July 2025 update.
* Adjusted the placement of the end tag for the "What's New" section in `whats-new.adoc` for better organization.