### PR TITLE
Update import federation notes

### DIFF
--- a/concept-federation.adoc
+++ b/concept-federation.adoc
@@ -23,7 +23,7 @@ Organization admin, Federation admin, Federation viewer. link:reference-iam-pred
 
 == Identity federation with NetApp Support Site
 
-When you federate with the NetApp Support Site, users can login with the same credentials to access BlueXP as you use for the NetApp Support Site, Active IQ Digital Advisor and other apps associated with your NetApp Support Site account.  After you set up federation, any new users who create a NetApp Support Site accounts will also be able to access BlueXP.
+When you federate with the NetApp Support Site, users can login with the same credentials to access BlueXP as you use for the NetApp Support Site, Active IQ Digital Advisor and other apps associated with your NetApp Support Site account.  After you set up federation, any new users who create a NetApp Support Site accounts are also be able to access BlueXP.
 
 
 NOTE: If you federate with the NetApp Support Site, you can't also federate with your corporate identity management provider. Choose which one works best for your organization.
@@ -42,6 +42,8 @@ The NetApp support team reviews and processes your request.
 
 == Set up a federated connection with your identity provider
 You can set up a federated connection with your identity provider to enable single sign-on (SSO) for BlueXP. The process involves configuring your identity provider to trust NetApp as a service provider and then creating the connection in BlueXP.
+
+NOTE: If you previously configured federation using NetApp Cloud Central (an external application to BlueXP), you'll need to import your federation using the BlueXP Federation page to be able to manage it within BlueXP. link:task-federation-import.html[Learn how to import your federation]
 
 === Supported identity providers
 
@@ -65,23 +67,23 @@ You can federate with your email domain or with a different domain that you own.
 .image:https://raw.githubusercontent.com/NetAppDocs/common/main/media/number-1.png[One] Verify your domain (if not using your email domain)
 
 [role="quick-margin-para"]
-If you want to federate with a domain that is different than your email domain, you must first verify that you own the domain. You can federate your email domain without any extra steps. 
+To federate with a domain different from your email domain, verify that you own it. You can federate your email domain without any extra steps. 
 
 .image:https://raw.githubusercontent.com/NetAppDocs/common/main/media/number-2.png[Two] Configure your IdP to trust NetApp as a service provider
 
 [role="quick-margin-para"]
-You configure your identity provider to trust NetApp as a service provider by creating a new application and providing the necessary information, such as the ACS URL, Entity ID or other credential information. Service provider information varies by identity provider, so refer to the documentation for your specific identity provider for details. You'll need to work with your IdP administrator to complete this step.
+Configure your identity provider to trust NetApp by creating a new application and providing the necessary information, such as the ACS URL, Entity ID or other credential information. Service provider information varies by identity provider, so refer to the documentation for your specific identity provider for details. You'll need to work with your IdP administrator to complete this step.
 
 
 .image:https://raw.githubusercontent.com/NetAppDocs/common/main/media/number-3.png[Three] Create the federated connection in BlueXP
 
 [role="quick-margin-para"]
-To create the connection, you'll need to provide the necessary information from your identity provider, such as the SAML metadata URL or file. This information is used to establish the trust relationship between BlueXP and your identity provider. The information you provide depends on the IdP that you are using. For example, if you're using Microsoft Entra ID, you'll need to provide the client ID, secret, and domain. 
+To create the connection, you need to provide the necessary information from your identity provider, such as the SAML metadata URL or file. This information is used to establish the trust relationship between BlueXP and your identity provider. The information you provide depends on the IdP that you are using. For example, if you're using Microsoft Entra ID, you need to provide the client ID, secret, and domain. 
 
 .image:https://raw.githubusercontent.com/NetAppDocs/common/main/media/number-4.png[Three] Test your federation in BlueXP
 
 [role="quick-margin-para"]
-Test your federated connection to ensure it works before enabling it. The Federation page in BlueXP provides a test option that allows you to verify your test user is able to authenticate successfully. If the test is successful, you can enable the connection.
+Test your federated connection before enabling it. The Federation page in BlueXP provides a test option that allows you to verify your test user is able to authenticate successfully. If the test is successful, you can enable the connection.
 
 .image:https://raw.githubusercontent.com/NetAppDocs/common/main/media/number-5.png[Three] Enable your connection in BlueXP
 

--- a/task-federation-import.adoc
+++ b/task-federation-import.adoc
@@ -13,7 +13,7 @@ summary: Import your existing federated connection to BlueXP to manage it in the
 :imagesdir: ./media/
 
 [.lead]
-Import your existing federated connection to BlueXP to manage it in the new interface. This allows you to take advantage of the latest enhancements without having to recreate your federated connections.
+If you have previously setup federation through NetApp Cloud Central (an external application to BlueXP) the Federation page prompts you to import your existing federated connection to BlueXP to manage it in the new interface. This allows you to take advantage of the latest enhancements without having to recreate your federated connections.
 
 Existing customers who have already set up federated connections to BlueXP can import their existing federations to the new interface. This allows you to manage your federated connections in the new Federations page without having to recreate them.
 

--- a/task-federation-manage.adoc
+++ b/task-federation-manage.adoc
@@ -15,6 +15,8 @@ summary: After you've added a federated connection, you can manage it in BlueXP.
 [.lead]
 You can manage your federation in BlueXP. You can disable it, update expired credentials, as well as disable it if you no longer need it.
 
+NOTE: If you previously configured federation using NetApp Cloud Central (an external application to BlueXP), you'll need to import your federation using the BlueXP Federation page to be able to manage it within BlueXP. link:task-federation-import.html[Learn how to import your federation]
+
 You can also add a verified domain to an existing federation, which allows you to use multiple domains for your federated connection.
 
 NOTE: Federation management events such as enabling, disabling, and updating federations display in the Timeline. link:task-monitor-cm-operations.html[Learn more about monitoring operations in BlueXP.]


### PR DESCRIPTION
This pull request updates documentation for federated identity management in BlueXP, focusing on clarifying the process for importing existing federations from NetApp Cloud Central and improving instructions for setting up and managing federated connections. The changes enhance user guidance and streamline the language for better readability.

**Federation import and management enhancements:**

* Added notes in `concept-federation.adoc` and `task-federation-manage.adoc` to inform users that federations previously configured in NetApp Cloud Central must be imported into BlueXP for management, with a link to import instructions. [[1]](diffhunk://#diff-eb70b3a4d58adc8dffb786130eae8cd338ca9654a9cc3b50a7fb09897919284aR46-R47) [[2]](diffhunk://#diff-617ace291f60194c5b788eecf732dbc6cac5e5d57060fb2f3ecc0c3d8c3fb34dR18-R19)
* Updated the lead section in `task-federation-import.adoc` to clarify that users are prompted to import existing federated connections from NetApp Cloud Central when accessing the Federation page in BlueXP.

**Process and language improvements:**

* Streamlined instructions and wording in the federation setup steps in `concept-federation.adoc` for clarity and conciseness, including domain verification, IdP configuration, connection creation, and testing.

**Minor correction:**

* Fixed a grammatical error in the description of NetApp Support Site federation in `concept-federation.adoc`.