### PR TITLE
fixing table

### DIFF
--- a/concept-modes.adoc
+++ b/concept-modes.adoc
@@ -397,7 +397,7 @@ https://docs.netapp.com/us-en/bluexp-backup-recovery/prev-ontap-protect-journey.
 | Volume caching | No | No
 | Workload factory | No | No
 
-.7+| *Features*
+.6+| *Features*
 | BlueXP identity and access management | Yes | Yes
 | Credentials | Yes | Yes 
 | NSS accounts | Yes | No 

--- a/reference-networking-saas-console.adoc
+++ b/reference-networking-saas-console.adoc
@@ -17,7 +17,7 @@ When you log in and use the web-based console, BlueXP contacts several endpoints
 
 These endpoints are contacted in two scenarios:
 
-* From a user's computer when completing sactions from the https://console.bluexp.netapp.com[BlueXP web-based console^] that's available as software as a service (SaaS).
+* From a user's computer when completing sections from the https://console.bluexp.netapp.com[BlueXP web-based console^] that's available as software as a service (SaaS).
 
 * From a user's computer when opening a web browser, entering the IP address of the Connector host, and then logging in and setting up the Connector. These steps are required if you manually install the Connector.
 


### PR DESCRIPTION
This pull request makes minor documentation corrections to improve clarity and accuracy in the BlueXP backup and recovery documentation. The changes primarily address a typo and a formatting issue.

* Documentation corrections:
  * Fixed a typo by changing "sactions" to "sections" in the description of actions performed from the BlueXP web-based console in `reference-networking-saas-console.adoc`.
  * Adjusted a table formatting issue by changing the row span from `.7+|` to `.6+|` for the "Features" section in `concept-modes.adoc`.