### PR TITLE
Bluexpdoc 823

### DIFF
--- a/reference-networking-saas-console.adoc
+++ b/reference-networking-saas-console.adoc
@@ -86,7 +86,7 @@ Suggestion: https://docs.aws.amazon.com/general/latest/gr/rande.html[See AWS doc
 |
 \https://netapp-cloud-account.auth0.com
 
-\https://netapp-cloud-account.us.auth0.com/
+\https://netapp-cloud-account.us.auth0.com
 
 \https://cdn.auth0.com
 

--- a/reference-networking-saas-console.adoc
+++ b/reference-networking-saas-console.adoc
@@ -86,6 +86,8 @@ Suggestion: https://docs.aws.amazon.com/general/latest/gr/rande.html[See AWS doc
 |
 \https://netapp-cloud-account.auth0.com
 
+\https://netapp-cloud-account.us.auth0.com/
+
 \https://cdn.auth0.com
 
 \https://services.cloud.netapp.com


### PR DESCRIPTION
This pull request adds a new Auth0 endpoint to the documentation, expanding the list of authentication URLs for the NetApp Cloud Account.

Networking and authentication documentation update:

* Added `https://netapp-cloud-account.us.auth0.com` to the list of Auth0 endpoints in `reference-networking-saas-console.adoc`, ensuring US-based authentication is documented.