### PR TITLE
bluexpdoc-883 fixing GNCV

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -133,6 +133,8 @@ sidebar:
                   url: /reference-iam-platform-roles.html
                 - title: Application roles
                   entries:
+                   - title: Google Cloud NetApp Volumes roles
+                     url: /reference-iam-gcnv-roles.html
                    - title: Keystone roles 
                      url: /reference-iam-keystone-roles.html
                    - title: Operations support analyst

--- a/reference-iam-predefined-roles.adoc
+++ b/reference-iam-predefined-roles.adoc
@@ -55,7 +55,7 @@ The following is a list of roles in the application category. Each role grants s
 |===
 | Application role | Responsibilities
 
-| link:reference-iam-keystone-roles.html[Google Cloud NetApp Volumes admin] | Users with the Google Cloud NetApp Volumes role can discover and manage Google Cloud NetApp Volumes.
+| link:reference-iam-gncv-roles.html[Google Cloud NetApp Volumes admin] | Users with the Google Cloud NetApp Volumes role can discover and manage Google Cloud NetApp Volumes.
 
 | link:reference-iam-keystone-roles.html[Keystone admin] | Users with the Keystone admin role can create service requests. Allows users to monitor and view consumption, assets, and administrative information within the Keystone tenant they are accessing.
 | link:reference-iam-keystone-roles.html[Keystone viewer] | Users with the Keystone viewer role CANNOT create service requests. Allows users to monitor and view consumption, assets, and administrative information within the Keystone tenant they are accessing.


### PR DESCRIPTION
This pull request introduces an update to the documentation for IAM roles, specifically adding a new entry for Google Cloud NetApp Volumes roles and correcting a broken link in the predefined roles table.

Documentation updates:

* Added a new sidebar entry for "Google Cloud NetApp Volumes roles" in `project.yml` to improve navigation and visibility of these roles.
* Fixed a broken link to the Google Cloud NetApp Volumes admin role in `reference-iam-predefined-roles.adoc`, updating it to the correct URL.